### PR TITLE
Photometry refactor

### DIFF
--- a/trialexp/process/pyphotometry/utils.py
+++ b/trialexp/process/pyphotometry/utils.py
@@ -1,7 +1,7 @@
 # Utility functions for pycontrol and pyphotometry files processing
 
 import json
-import pandas as pd
+
 from matplotlib import pyplot as plt
 import numpy as np
 from sklearn.mixture import GaussianMixture
@@ -206,7 +206,10 @@ def import_ppd(file_path, low_pass=20, high_pass=0.01, medfilt_size=None):
                  'pulse_times_1' : pulse_times_1,
                  'pulse_times_2' : pulse_times_2,
                  'time'          : time}
+    
+    # Add metadata to dictionary.
     data_dict.update(header_dict)
+    
     return data_dict
 
 

--- a/trialexp/process/pyphotometry/utils.py
+++ b/trialexp/process/pyphotometry/utils.py
@@ -13,7 +13,20 @@ from sklearn.preprocessing import StandardScaler
 
 from scipy.optimize import curve_fit
 from scipy.signal import butter, filtfilt, medfilt
+from scipy.stats import linregress, zscore
+
 from trialexp.utils.rsync import *
+
+'''
+Most of the photometry data processing functions are based on the intial design
+of the pyPhotometry package. They are stored in a dictionary containing both
+metadata and the data. The dictionary is returned by the import_ppd function.
+
+Assumptions:
+    - Analog 1 is the isosbestic control
+    - Analog 2 is the signal of interest
+'''
+
 
 #----------------------------------------------------------------------------------
 # Plotting
@@ -25,21 +38,48 @@ from trialexp.utils.rsync import *
 #----------------------------------------------------------------------------------
 
 #----------------------------------------------------------------------------------
-# Filtering / Motion correction / resampling 
+# Motion correction / Normalization 
 #----------------------------------------------------------------------------------
 
+# Note that there is a dependency in the workflow between these filtering 
+# and normalization functions. The normalization functions assume that the
+# data has already been filtered.
 
-def motion_correction():
-    ...
+def motion_correction(photometry_dict: dict) -> dict:
+    
+    if any(['analog_1_filt' not in photometry_dict, 'analog_2_filt' not in photometry_dict]):
+        raise Exception('Analog 1 and Analog 2 must be filtered before motion correction')
+    
+    slope, intercept, r_value, p_value, std_err = linregress(x=photometry_dict['analog_2_filt'], y=photometry_dict['analog_1_filt'])
+    photometry_dict['analog_1_est_motion'] = intercept + slope * photometry_dict['analog_2_filt']
+    photometry_dict['analog_1_corrected'] = photometry_dict['analog_1_filt'] - photometry_dict['analog_1_est_motion']
+    
+    return photometry_dict
+
+def compute_df_over_f(photometry_dict: dict, low_pass_cutoff: float = 0.001) -> dict:
+    
+    if 'analog_1_corrected' not in photometry_dict:
+        raise Exception('Analog 1 must be motion corrected before computing dF/F')
+    
+    b,a = butter(2, low_pass_cutoff, btype='low', fs=photometry_dict['sampling_rate'])
+    photometry_dict['analog_1_baseline_fluo'] = filtfilt(b,a, photometry_dict['analog_1_filt'], padtype='even')
+
+    # Now calculate the dF/F by dividing the motion corrected signal by the time varying baseline fluorescence.
+    photometry_dict['analog_1_df_over_f'] = photometry_dict['analog_1_corrected'] / photometry_dict['analog_1_baseline_fluo'] 
+    
+    return photometry_dict
 
 #----------------------------------------------------------------------------------
-# Filtering / Motion correction / resampling 
+# Filtering 
 #----------------------------------------------------------------------------------
 
 def median_filtering(data, medfilt_size: int = 3) -> np.ndarray:
+    
     if medfilt_size % 2 == 0:
         raise Exception('medfilt_size must be an odd number') 
+    
     data = medfilt(data,medfilt_size)
+    
     return data
 
 def get_filt_coefs(low_pass: int = None, high_pass: int = None, sampling_rate = 1000):
@@ -49,18 +89,24 @@ def get_filt_coefs(low_pass: int = None, high_pass: int = None, sampling_rate = 
         b, a = butter(2, low_pass/(0.5*sampling_rate), 'low')
     elif high_pass:
         b, a = butter(2, high_pass/(0.5*sampling_rate), 'high')
+    
     return b,a
 
 #----------------------------------------------------------------------------------
-# Helpers
+# Exponential fitting currently not in use in our pipelines
 #----------------------------------------------------------------------------------
 
 # The exponential curve we are going to fit.
 def exp_func(x, a, b, c):
    return a*np.exp(-b*x) + c
 
-# compute the exponential fitted to data
+
 def fit_exp_func(data, fs: int = 100, medfilt_size: int = 3) -> np.ndarray:
+    '''
+    compute the exponential fitted to data. This unused in current filtering because
+    unsuitable when behavioural box openings / closing provoked transitory changes
+    in baseline fluorescence.
+    '''
     if medfilt_size % 2 == 0:
         raise Exception('medfilt_size must be an odd number') 
     

--- a/trialexp/utils/data_organisation.py
+++ b/trialexp/utils/data_organisation.py
@@ -1,0 +1,133 @@
+import shutil
+from os.path import join, isfile 
+from os import listdir, walk
+
+import pandas as pd
+
+from trialexp.utils.pycontrol_utilities import get_datetime_from_datestr, get_datestr_from_filename
+#----------------------------------------------------------------------------------
+# Data reorganization
+#----------------------------------------------------------------------------------
+
+def copy_files_to_horizontal_folders(root_folders, horizontal_folder_pycontrol, horizontal_folder_photometry):
+    '''
+    Browse sub-folders (in a single root folder or within a list of root folder)
+    and copy them in a separate horizontal folders (no subfolders). The main
+    purpose is for easier match between pycontrol and photometry files
+ 
+    '''
+    
+    if isinstance(root_folders, str):
+        root_folders = [root_folders]
+
+    for root in root_folders:
+        for path, subdirs, files in walk(root):
+            for name in files:
+
+                if name[-4:] == '.txt':
+                    if not isfile(join(horizontal_folder_pycontrol,name)):
+                        print(join(path, name))
+                        shutil.copyfile(join(path, name),join(horizontal_folder_pycontrol, name))
+                elif name[-4:] == '.ppd':
+                    if not isfile(join(horizontal_folder_photometry, name)):
+                        print(join(path, name))
+                        shutil.copyfile(join(path, name),join(horizontal_folder_photometry, name))
+
+
+#----------------------------------------------------------------------------------
+# Helpers
+#----------------------------------------------------------------------------------
+
+def match_sessions_to_files(experiment, files_dir, ext='mp4', verbose=False) -> str:
+    '''
+    Refactoring note: need to be implemented as a standalone method for single
+    py control files but would probably be much slower as it will have to 
+    constantly browse folders of other data modalities to list all the files. 
+    Can be useful as is for data reorganization purposes.
+    
+    Take an experiment instance and look for files within a directory
+    taken the same day as the session and containing the subject_ID,
+    store the filename(s) with the shortest timedelta compared to the
+    start of the session in exp.sessions[x].files["ext"] as a list
+    
+            Parameters:
+                    file_name (str): name of the file to look for
+                    files_dir (str): path of the directory to look into to find a match
+                    ext (str): extension used to filter files within a folder
+                        do not include the dot. e.g.: "mp4"
+
+            Returns:
+                    str (store list in sessions[x].file["ext"])
+    ''' 
+
+    # subject_IDs = [session.subject_ID for session in self.sessions]
+    # datetimes = [session.datetime for session in self.sessions]
+    files_list = [f for f in listdir(files_dir) if isfile(
+        join(files_dir, f)) and ext in f]
+
+    if len(files_list) == 0:
+        raise Exception(f'No files with the .{ext} extension where found in the following folder: {files_dir}')
+
+    files_df = pd.DataFrame(columns=['filename','datetime'])
+
+    files_df['filename'] = pd.DataFrame(files_list)
+    files_df['datetime'] = files_df['filename'].apply(lambda x: get_datetime_from_datestr(get_datestr_from_filename(x)))
+    # print(files_df['datetime'])
+    for s_idx, session in enumerate(experiment.sessions):
+        match_df = find_matching_files(session.subject_ID, session.datetime, files_df, ext)
+        if verbose:
+            print(session.subject_ID, session.datetime, match_df['filename'].values)
+        
+        if not hasattr(experiment.sessions[s_idx], 'files'):
+            experiment.sessions[s_idx].files = dict()
+        
+        experiment.sessions[s_idx].files[ext] = [join(files_dir, filepath) for filepath in match_df['filename'].to_list()]
+
+    return experiment
+
+def find_matching_files(subject_ID, datetime_to_match, files_df, ext):
+    """
+    Helper function for match_sessions_to_files, find files with
+    the same subject_ID in the filename, and taken the same day
+    as the pycontrol session, return the file(s) with the shortest
+    timedelta compared to the start of the session.
+    
+    
+            Parameters:
+                    subject_ID (int): from session.subject_ID (need to be converted
+                        from string to int if int_subject_IDs=False at Session object creation)
+                    datetime_to_match (datetime): from session.datetime
+                    files_df (pd.Dataframe): Created from a list of files in 
+                        match_sessions_to_files function
+                    ext (str): extension used to filter files within a folder
+                        do not include the dot. e.g.: "mp4"
+
+            Returns:
+                    match_df (pd.Dataframe): containing filenames of matching files
+    """ 
+
+    if ext not in ['nwb','h5']:
+        # for videos, avoid integrating DeepLabCut labelled videos "['filename'].str.contains('DLC')"
+        #TODO match_df is not a view or copy
+        match_df = files_df.loc[(files_df['datetime'].apply(lambda x: pd.Timestamp.date(x)) == datetime_to_match.date()) &
+            (files_df['filename'].str.contains(str(subject_ID))) &
+            ~(files_df['filename'].str.contains('DLC'))].copy() 
+
+        # will not avoid DLC-containing filenames in case of searching DLC .nwb data files
+    else:
+        match_df = files_df.loc[(files_df['datetime'].apply(lambda x: pd.Timestamp.date(x)) == datetime_to_match.date()) &
+                                (files_df['filename'].str.contains(str(subject_ID)))].copy() #TODO match_df is not a view or copy
+
+    # match_df = match_df.to_frame(name='matching_filename')
+    if ~match_df.empty:
+      
+        # Compute time difference between the files
+        match_df['timedelta'] = match_df['datetime'].apply(
+            lambda x: abs(datetime_to_match-x))
+
+        # Take the file with the minimum time difference
+        match_df = match_df[match_df['timedelta'] == match_df['timedelta'].min()]
+        #print(match_df['timedelta'])
+        match_df['timedelta'] = match_df['timedelta'].apply(lambda x: x.seconds)
+    
+    return match_df

--- a/trialexp/utils/pycontrol_utilities.py
+++ b/trialexp/utils/pycontrol_utilities.py
@@ -1,18 +1,21 @@
-# Utility functions for pycontrol and pyphotometry files processing
+'''
+These utilities contained originally much more methods, which have been moved
+to more appropriate modules during refactoring.
 
-import shutil
+It still contains mostly date matching patterns methods and helper methods
+to find events timestamps for differential trial alignment.
 
-from os.path import join, isfile, isdir
-from os import walk, listdir
+It is possibly best to store the remaining methods in appropriate modules
+'''
+
 from datetime import datetime
 from re import search
 
 import numpy as np
-import pandas as pd
 
-import matplotlib.pyplot as plt
-import matplotlib as mpl
 
+'''
+following is depracted until possible re-use elsewhere
 #----------------------------------------------------------------------------------
 # Plotting
 #----------------------------------------------------------------------------------
@@ -47,103 +50,7 @@ def plot_longitudinal(results, plot_individuals=True):
                 axs[row, col].set_ylabel(metric_name, fontsize=fontsize)
                 axs[row, col].set_title('Title', fontsize=fontsize)
 
-#----------------------------------------------------------------------------------
-# Helpers
-#----------------------------------------------------------------------------------
-
-def match_sessions_to_files(experiment, files_dir, ext='mp4', verbose=False) -> str:
-    '''
-    Refactoring note: need to be implemented as a standalone method for single
-    py control files but would probably be much slower as it will have to 
-    constantly browse folders of other data modalities to list all the files. 
-    Can be useful as is for data reorganization purposes.
-    
-    Take an experiment instance and look for files within a directory
-    taken the same day as the session and containing the subject_ID,
-    store the filename(s) with the shortest timedelta compared to the
-    start of the session in exp.sessions[x].files["ext"] as a list
-    
-            Parameters:
-                    file_name (str): name of the file to look for
-                    files_dir (str): path of the directory to look into to find a match
-                    ext (str): extension used to filter files within a folder
-                        do not include the dot. e.g.: "mp4"
-
-            Returns:
-                    str (store list in sessions[x].file["ext"])
-    ''' 
-
-    # subject_IDs = [session.subject_ID for session in self.sessions]
-    # datetimes = [session.datetime for session in self.sessions]
-    files_list = [f for f in listdir(files_dir) if isfile(
-        join(files_dir, f)) and ext in f]
-
-    if len(files_list) == 0:
-        raise Exception(f'No files with the .{ext} extension where found in the following folder: {files_dir}')
-
-    files_df = pd.DataFrame(columns=['filename','datetime'])
-
-    files_df['filename'] = pd.DataFrame(files_list)
-    files_df['datetime'] = files_df['filename'].apply(lambda x: get_datetime_from_datestr(get_datestr_from_filename(x)))
-    # print(files_df['datetime'])
-    for s_idx, session in enumerate(experiment.sessions):
-        match_df = find_matching_files(session.subject_ID, session.datetime, files_df, ext)
-        if verbose:
-            print(session.subject_ID, session.datetime, match_df['filename'].values)
-        
-        if not hasattr(experiment.sessions[s_idx], 'files'):
-            experiment.sessions[s_idx].files = dict()
-        
-        experiment.sessions[s_idx].files[ext] = [join(files_dir, filepath) for filepath in match_df['filename'].to_list()]
-
-    return experiment
-
-def find_matching_files(subject_ID, datetime_to_match, files_df, ext):
-    """
-    Helper function for match_sessions_to_files, find files with
-    the same subject_ID in the filename, and taken the same day
-    as the pycontrol session, return the file(s) with the shortest
-    timedelta compared to the start of the session.
-    
-    
-            Parameters:
-                    subject_ID (int): from session.subject_ID (need to be converted
-                        from string to int if int_subject_IDs=False at Session object creation)
-                    datetime_to_match (datetime): from session.datetime
-                    files_df (pd.Dataframe): Created from a list of files in 
-                        match_sessions_to_files function
-                    ext (str): extension used to filter files within a folder
-                        do not include the dot. e.g.: "mp4"
-
-            Returns:
-                    match_df (pd.Dataframe): containing filenames of matching files
-    """ 
-
-    if ext not in ['nwb','h5']:
-        # for videos, avoid integrating DeepLabCut labelled videos "['filename'].str.contains('DLC')"
-        #TODO match_df is not a view or copy
-        match_df = files_df.loc[(files_df['datetime'].apply(lambda x: pd.Timestamp.date(x)) == datetime_to_match.date()) &
-            (files_df['filename'].str.contains(str(subject_ID))) &
-            ~(files_df['filename'].str.contains('DLC'))].copy() 
-
-        # will not avoid DLC-containing filenames in case of searching DLC .nwb data files
-    else:
-        match_df = files_df.loc[(files_df['datetime'].apply(lambda x: pd.Timestamp.date(x)) == datetime_to_match.date()) &
-                                (files_df['filename'].str.contains(str(subject_ID)))].copy() #TODO match_df is not a view or copy
-
-    # match_df = match_df.to_frame(name='matching_filename')
-    if ~match_df.empty:
-      
-        # Compute time difference between the files
-        match_df['timedelta'] = match_df['datetime'].apply(
-            lambda x: abs(datetime_to_match-x))
-
-        # Take the file with the minimum time difference
-        match_df = match_df[match_df['timedelta'] == match_df['timedelta'].min()]
-        #print(match_df['timedelta'])
-        match_df['timedelta'] = match_df['timedelta'].apply(lambda x: x.seconds)
-    
-    return match_df
+'''
     
 def get_datetime_from_datestr(datestr: str):
     '''
@@ -165,7 +72,9 @@ def get_datetime_from_datestr(datestr: str):
             continue
 
 def get_datestr_from_filename(filename: str):
-    '''   
+    ''' 
+        Should probably be refactored with strftime
+        
         PyControl and other files like videos and DLC data may
         have different date formats in their filenames.
         The purpose of this function is to reconcile these differences
@@ -176,7 +85,6 @@ def get_datestr_from_filename(filename: str):
         
         Add more patterns as needed
 
-        Should be refactored with strftime possibly
     '''
 
     re_patterns = [
@@ -283,6 +191,8 @@ def time_delta_by_row(df_events_row, col_idx_start, col_idx_end):
         else:
             return np.NaN
 
+'''
+# Kouichi's helper, appears not to be used
 def cmap10():
     """
     Default plot colors of matplotlib.pyplot.plot, turned into colormap
@@ -292,7 +202,7 @@ def cmap10():
         ) # default 10 colors
 
     return cmap
-
+'''
 def get_methods(obj):
     """
     obj.__dict__
@@ -352,33 +262,6 @@ def get_attributes_and_properties(obj):
 
     return [attrnames, propnames]
 
-#----------------------------------------------------------------------------------
-# Data reorganization
-#----------------------------------------------------------------------------------
-
-def copy_files_to_horizontal_folders(root_folders, horizontal_folder_pycontrol, horizontal_folder_photometry):
-    '''
-    Browse sub-folders (in a single root folder or within a list of root folder)
-    and copy them in a separate horizontal folders (no subfolders). The main
-    purpose is for easier match between pycontrol and photometry files
- 
-    '''
-    
-    if isinstance(root_folders, str):
-        root_folders = [root_folders]
-
-    for root in root_folders:
-        for path, subdirs, files in walk(root):
-            for name in files:
-
-                if name[-4:] == '.txt':
-                    if not isfile(join(horizontal_folder_pycontrol,name)):
-                        print(join(path, name))
-                        shutil.copyfile(join(path, name),join(horizontal_folder_pycontrol, name))
-                elif name[-4:] == '.ppd':
-                    if not isfile(join(horizontal_folder_photometry, name)):
-                        print(join(path, name))
-                        shutil.copyfile(join(path, name),join(horizontal_folder_photometry, name))
 
 #----------------------------------------------------------------------------------
 # Load analog data

--- a/trialexp/utils/pycontrol_utilities.py
+++ b/trialexp/utils/pycontrol_utilities.py
@@ -74,7 +74,7 @@ def get_datetime_from_datestr(datestr: str):
 def get_datestr_from_filename(filename: str):
     ''' 
         Should probably be refactored with strftime
-        
+
         PyControl and other files like videos and DLC data may
         have different date formats in their filenames.
         The purpose of this function is to reconcile these differences
@@ -268,7 +268,12 @@ def get_attributes_and_properties(obj):
 #----------------------------------------------------------------------------------
 
 def load_analog_data(file_path):
-    '''Load a pyControl analog data file and return the contents as a numpy array
-    whose first column is timestamps (ms) and second data values.'''
+    '''
+    Load a pyControl analog data file and return the contents as a numpy array
+    whose first column is timestamps (ms) and second data values.
+    
+    This is to be used for example to import treadmill or piezzo sensor data 
+    acquired by pyControl.
+    '''
     with open(file_path, 'rb') as f:
         return np.fromfile(f, dtype='<i').reshape(-1,2)


### PR DESCRIPTION
Merging changes that add the reorg_to_sessions_folder methods so that we can begin to trial new folder organization, and to receive feedback.

Note that one of the meaningful change should be the way you find matching files, but Experiment method and the standalone function match_sessions_to_files are still co-existing for now. On purpose to not break things.

Otherwise break down photometry processing and importing into smaller functions. trialexp/process/photometry/utils.py will be the default place for photometry methods from now on, as suggested by Teris in https://github.com/juliencarponcy/trialexp/pull/5

I will continue proper photometry refactor in the dedicated branch
