### PR TITLE
write up to 400 channels in Spike2

### DIFF
--- a/trialexp/process/pycontrol/spike2_export.py
+++ b/trialexp/process/pycontrol/spike2_export.py
@@ -19,7 +19,7 @@ class Spike2Exporter:
         if mtc is None:
             raise Exception('smrx_filename has to end with .smrx')
 
-        self.MyFile = sp.SonFile(smrx_filename)
+        self.MyFile = sp.SonFile(smrx_filename, nChans = int(400)) # Allow up to 400 channels
         self.smrx_filename = smrx_filename
         self.CurChan = 0
         self.UsedChans = 0


### PR DESCRIPTION
Apparently, `nChans = int(400)` is needed to export more than 32 channels into Spike2
works with sonpy1.9.5 but not 1.8.5