### PR TITLE
Spike sorting minor fix

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@
 # KILOSORT3_PATH = C:\Users\phar0732\Documents\GitHub\trialexp\Kilosort
 SNAKEMAKE_DEBUG_ROOT = /home/MRC.OX.AC.UK/phar0732/Documents/GitHub/trialexp
 KILOSORT3_PATH=/home/MRC.OX.AC.UK/phar0732/Documents/GitHub/Kilosort
+SORTING_ROOT_DATA_PATH =/home/MRC.OX.AC.UK/phar0732/ettin/
+SESSION_ROOT_DIR=/home/MRC.OX.AC.UK/phar0732/ettin/Data/head-fixed/by_sessions/

--- a/workflows/config/config.yaml
+++ b/workflows/config/config.yaml
@@ -1,2 +1,0 @@
-session_root_dir: '/home/MRC.OX.AC.UK/phar0732/ettin/Data/head-fixed/by_sessions/'
-# neuropixels_root_dir: '\\ettin\Magill_Lab\Julien\Data\head-fixed\openephys'

--- a/workflows/scripts/settings.py
+++ b/workflows/scripts/settings.py
@@ -1,5 +1,6 @@
+import os
 # debug_folder = r'//ettin/Magill_Lab/Teris/ASAP/expt_sessions/kms063-2023-02-27-164426/'
 # debug_folder = r'//home/MRC.OX.AC.UK/phar0732/ettin/Data/head-fixed/_Other/test_folder_ephys/kms058_2023-03-24_15-09-44_bar_final/Record Node 101/experiment1/recording1/continuous/Neuropix-PXI-100.ProbeA-AP/sorting/'
 
-debug_folder = r'/home/MRC.OX.AC.UK/phar0732/ettin/Data/head-fixed/by_sessions/reaching_go_spout_bar_nov22/kms058-2023-03-14-165110'
+debug_folder = os.path.join(os.environ['SESSION_ROOT_DIR'], 'reaching_go_spout_bar_nov22', 'kms058-2023-03-14-165110')
 # debug_folder = r'/home/MRC.OX.AC.UK/phar0732/ettin/Data/head-fixed/by_sessions/reaching_go_spout_bar_nov22/kms062-2023-03-06-182344'

--- a/workflows/spikesort.smk
+++ b/workflows/spikesort.smk
@@ -1,12 +1,9 @@
 from glob import glob
 from pathlib import Path
-
-configfile : 'workflows/config/config.yaml'
-# report: 'report/workflow.rst'
-
+import os 
 
 rule all:
-    input: expand('{sessions}/processed/spike_sorting.done', sessions = Path(config['session_root_dir']).glob('*/*'))
+    input: expand('{sessions}/processed/spike_sorting.done', sessions = Path(os.environ.get('SESSION_ROOT_DIR')).glob('*/*'))
 
 
 # rule create_folder:
@@ -27,8 +24,8 @@ rule spike_sorting:
     input:
         rec_properties = rec_properties_input
     output:
-        spike_templateA = '{session_path}/{task_path}/{session_id}/ephys/sorted/probeA/spike_templates.npy',
-        spike_templateB = '{session_path}/{task_path}/{session_id}/ephys/sorted/probeB/spike_templates.npy',
+        output_folder = directory('{session_path}/{task_path}/{session_id}/ephys/output')
+        sorting_folder = directory('{session_path}/{task_path}/{session_id}/ephys/sorting')
         rule_complete = touch(r'{session_path}/{task_path}/{session_id}/processed/spike_sorting.done')
     log:
         '{session_path}/{task_path}/{session_id}/processed/log/process_spike_sorting.log'

--- a/workflows/spikesort.smk
+++ b/workflows/spikesort.smk
@@ -3,7 +3,7 @@ from pathlib import Path
 import os 
 
 rule all:
-    input: expand('{sessions}/processed/spike_sorting.done', sessions = Path(os.environ.get('SESSION_ROOT_DIR')).glob('*/*'))
+    input: expand('{sessions}/processed/spike_workflow.done', sessions = Path(os.environ.get('SESSION_ROOT_DIR')).glob('*/*'))
 
 
 # rule create_folder:
@@ -12,17 +12,11 @@ rule all:
 #     script:
 #         'scripts/s00_create_session_folders.py'
 
-def rec_properties_input(wildcards):
-    # determine if there is an ephys recording for that folder
-    recording_csv = glob(f'{wildcards.session_path}/{wildcards.task_path}/{wildcards.session_id}/ephys/rec_properties.csv')
-    if len(recording_csv) > 0:
-        return f'{wildcards.session_path}/{wildcards.task_path}/{wildcards.session_id}/ephys/rec_properties.csv'
-    else:
-        return []
+
 
 rule spike_sorting:
     input:
-        rec_properties = rec_properties_input
+        rec_properties = '{session_path}/{task_path}/{session_id}/ephys/rec_properties.csv'
     output:
         output_folder = directory('{session_path}/{task_path}/{session_id}/ephys/output'),
         sorting_folder = directory('{session_path}/{task_path}/{session_id}/ephys/sorting'),
@@ -32,8 +26,16 @@ rule spike_sorting:
     script:
         'scripts/s01_sort_ks3.py'
 
+def rec_properties_input(wildcards):
+    # determine if there is an ephys recording for that folder
+    recording_csv = glob(f'{wildcards.session_path}/{wildcards.task_path}/{wildcards.session_id}/ephys/rec_properties.csv')
+    if len(recording_csv) > 0:
+        return f'{wildcards.session_path}/{wildcards.task_path}/{wildcards.session_id}/processed/spike_sorting.done'
+    else:
+        return []
+
 rule final:
     input:
-        spike_sorting_done = '{session_path}/{task_path}/{session_id}/processed/spike_sorting.done'
+        spike_sorting_done = rec_properties_input,
     output:
         done = touch('{session_path}/{task_path}/{session_id}/processed/spike_workflow.done')

--- a/workflows/spikesort.smk
+++ b/workflows/spikesort.smk
@@ -24,8 +24,8 @@ rule spike_sorting:
     input:
         rec_properties = rec_properties_input
     output:
-        output_folder = directory('{session_path}/{task_path}/{session_id}/ephys/output')
-        sorting_folder = directory('{session_path}/{task_path}/{session_id}/ephys/sorting')
+        output_folder = directory('{session_path}/{task_path}/{session_id}/ephys/output'),
+        sorting_folder = directory('{session_path}/{task_path}/{session_id}/ephys/sorting'),
         rule_complete = touch(r'{session_path}/{task_path}/{session_id}/processed/spike_sorting.done')
     log:
         '{session_path}/{task_path}/{session_id}/processed/log/process_spike_sorting.log'

--- a/workflows/spout_bar_nov22.smk
+++ b/workflows/spout_bar_nov22.smk
@@ -1,73 +1,78 @@
 from glob import glob
 from pathlib import Path
-
-configfile : 'workflows/config/config.yaml'
-# report: 'report/workflow.rst'
+import os
 
 rule all:
-    input: expand('{sessions}/processed/task.done', sessions = Path(config['session_root_dir']).glob('*'))
+    input: expand('{sessions}/processed/task.done', sessions = Path(os.environ.get('SESSION_ROOT_DIR')).glob('*/*'))
 
 rule process_pycontrol:
     input:
-        session_path = '{session_path}/{session_id}'
+        session_path = '{session_path}/{task}/{session_id}'
     output:
-        event_dataframe = '{session_path}/{session_id}/processed/df_events_cond.pkl',
-        condition_dataframe = '{session_path}/{session_id}/processed/df_conditions.pkl',
-        pycontrol_dataframe = '{session_path}/{session_id}/processed/df_pycontrol.pkl',
-        trial_dataframe = '{session_path}/{session_id}/processed/df_trials.pkl'
+        event_dataframe = '{session_path}/{task}/{session_id}/processed/df_events_cond.pkl',
+        condition_dataframe = '{session_path}/{task}/{session_id}/processed/df_conditions.pkl',
+        pycontrol_dataframe = '{session_path}/{task}/{session_id}/processed/df_pycontrol.pkl',
+        trial_dataframe = '{session_path}/{task}/{session_id}/processed/df_trials.pkl'
     log:
-        '{session_path}/{session_id}/processed/log/process_pycontrol.log'
+        '{session_path}/{task}/{session_id}/processed/log/process_pycontrol.log'
     script:
         'scripts/01_process_pycontrol.py'
 
 rule pycontrol_figures:
     input:
-        event_dataframe = '{session_path}/{session_id}//processed/df_events_cond.pkl'
+        event_dataframe = '{session_path}/{task}/{session_id}/processed/df_events_cond.pkl'
     log:
-        '{session_path}/{session_id}/processed/log/pycontrol_figures.log'
+        '{session_path}/{task}/{session_id}/processed/log/pycontrol_figures.log'
     output:
-        event_histogram = report('{session_path}/{session_id}//processed/figures/event_histogram_{session_id}.png', 
+        event_histogram = report('{session_path}/{task}/{session_id}/processed/figures/event_histogram_{session_id}.png', 
                                     caption='report/event_histogram.rst', category='Plots' ),
-        rule_complete = touch('{session_path}/{session_id}/processed/log/pycontrol.done')
+        rule_complete = touch('{session_path}/{task}/{session_id}/processed/log/pycontrol.done')
     script:
         'scripts/02_plot_pycontrol_data.py'
 
 rule export_spike2:
     input:
-        pycontrol_dataframe = '{session_path}/{session_id}/processed/df_pycontrol.pkl',
-        df_photometry = '{session_path}/{session_id}/processed/xr_photometry.nc'
+        pycontrol_dataframe = '{session_path}/{task}/{session_id}/processed/df_pycontrol.pkl',
+        df_photometry = '{session_path}/{task}/{session_id}/processed/xr_photometry.nc'
     output:
-        spike2_file = '{session_path}/{session_id}/processed/spike2.smrx',
+        spike2_file = '{session_path}/{task}/{session_id}/processed/spike2.smrx',
     script:
         'scripts/03_export_spike2.py'
 
-
 rule import_pyphotometry:
     input:
-        pycontrol_dataframe = '{session_path}/{session_id}/processed/df_pycontrol.pkl',
-        trial_dataframe = '{session_path}/{session_id}/processed/df_trials.pkl',
-        event_dataframe = '{session_path}/{session_id}/processed/df_events_cond.pkl',
-        condition_dataframe = '{session_path}/{session_id}/processed/df_conditions.pkl',
-        photometry_folder = '{session_path}/{session_id}/pyphotometry'
+        pycontrol_dataframe = '{session_path}/{task}/{session_id}/processed/df_pycontrol.pkl',
+        trial_dataframe = '{session_path}/{task}/{session_id}/processed/df_trials.pkl',
+        event_dataframe = '{session_path}/{task}/{session_id}/processed/df_events_cond.pkl',
+        condition_dataframe = '{session_path}/{task}/{session_id}/processed/df_conditions.pkl',
+        photometry_folder = '{session_path}/{task}/{session_id}/pyphotometry'
     output:
-        xr_photometry = '{session_path}/{session_id}/processed/xr_photometry.nc',
-        xr_session = '{session_path}/{session_id}/processed/xr_session.nc',
+        xr_photometry = '{session_path}/{task}/{session_id}/processed/xr_photometry.nc',
+        xr_session = '{session_path}/{task}/{session_id}/processed/xr_session.nc',
     script:
         'scripts/04_import_pyphotometry.py'
 
 rule photometry_figure:
     input:
-        xr_session = '{session_path}/{session_id}/processed/xr_session.nc',
+        xr_session = '{session_path}/{task}/{session_id}/processed/xr_session.nc',
     output:
-        trigger_photo_dir= directory('{session_path}/{session_id}/processed/figures/photometry'),
-        rule_complete = touch('{session_path}/{session_id}/processed/log/photometry.done')
+        trigger_photo_dir= directory('{session_path}/{task}/{session_id}/processed/figures/photometry'),
+        rule_complete = touch('{session_path}/{task}/{session_id}/processed/log/photometry.done')
     script:
         'scripts/05_plot_pyphotometry.py'
 
+def photometry_input(wildcards):
+    #determine if photometry needs to run in the current folder
+    ppd_files = glob(f'{wildcards.session_path}/{wildcards.task}/{wildcards.session_id}/pyphotometry/*.ppd')
+    if len(ppd_files)>0:
+        return f'{wildcards.session_path}/{wildcards.task}/{wildcards.session_id}/processed/log/photometry.done'
+    else:
+        return []
+
 rule final:
     input:
-        photometry_done = '{session_path}/{session_id}/processed/log/photometry.done',
-        pycontrol_done = '{session_path}/{session_id}/processed/log/pycontrol.done',
-        spike2='{session_path}/{session_id}/processed/spike2.smrx'
+        photometry_done = photometry_input,
+        pycontrol_done = '{session_path}/{task}/{session_id}/processed/log/pycontrol.done',
+        spike2='{session_path}/{task}/{session_id}/processed/spike2.smrx'
     output:
-        done = touch('{session_path}/{session_id}/processed/task.done')
+        done = touch('{session_path}/{task}/{session_id}/processed/task.done')


### PR DESCRIPTION
This PR contains some minor fixes for the spike sorting branch

1. Move all configurations into one env file, so that it is easier to change them. Also, using env variables allow us to just set them in the running machine directly, allowing different users to run the same script (different user may have different mount location)
2. Change the folder output of the sorting slightly so that spikeinterface won't complain about existing folders. The output folder for sorting and the one we use to save the sorting extractor should be in different folders.
3.  Reorganize the rule dependencies in the sorting snakefile so that the input function is in the last step, so that it can give a more accurate estimation of the number of sorting that needs to be run in the snakemake stats. 