### PR TITLE
plt.rcParams['axes.spines.top'] = False

### DIFF
--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -12,6 +12,12 @@ def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=
     #   can be used to configure additional plotting scales
     # # Use joingrid directly because the x and y axis are usually in different units
 
+    plt.rcParams['axes.spines.top'] = False
+    plt.rcParams['axes.spines.right'] = False
+    plt.rcParams['xtick.direction'] = 'out'
+    plt.rcParams['ytick.direction'] = 'out'
+    plt.rcParams["legend.frameon"] = False
+    plt.rcParams['font.family'] = 'Arial'
 
     g = sns.JointGrid()
     ax = sns.scatterplot(y=y, x=x, marker='|' ,

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -30,7 +30,7 @@ The snakemake file (`*.smk`) that defines the workflow is in the `workflow` fold
 
 ## Usage
 
-### Copying file to `by_session` folder
+### Copying files to `by_session` folder
 We first need to copy files to the `by_session` folder. You can do that by
 
 ```

--- a/workflow/scripts/05_plot_pyphotometry.py
+++ b/workflow/scripts/05_plot_pyphotometry.py
@@ -28,6 +28,15 @@ xr_session = xr.open_dataset(sinput.xr_session)
 figure_dir = soutput.trigger_photo_dir
 
 #%% plot all event-related data
+
+sns.set_style("white", {
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "xtick.direction": "out",
+    "ytick.direction": "out",
+    "font.family": ["Arial"]
+    })
+
 for k in xr_session.data_vars.keys():
     da = xr_session[k]
     if 'event_time' in da.coords:
@@ -39,6 +48,7 @@ for k in xr_session.data_vars.keys():
 
           ax = sns.lineplot(x='event_time',hue='success', y=k, data=df2plot)
           ax.set(ylabel=k, xlabel='Time (ms)')
+          ax.legend(frameon=False)
 
           fig.savefig(os.path.join(figure_dir, f'{k}.png'), dpi=300, bbox_inches='tight')
 


### PR DESCRIPTION
Forcing the default plot style

```python
plt.rcParams['axes.spines.right'] = False
plt.rcParams['xtick.direction'] = 'out'
plt.rcParams['ytick.direction'] = 'out'
plt.rcParams["legend.frameon"] = False
plt.rcParams['font.family'] = 'Arial'
```