### PR TITLE
Figure improvement

### DIFF
--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -15,7 +15,8 @@ trial_outcome_palette = {
     'late_reach': default_palette[3],
     'no_reach': default_palette[4],
     'water_by_bar_off': default_palette[5],
-    'undefined': default_palette[6]
+    'undefined': default_palette[6],
+    'not success': default_palette[7]
     
 }
 

--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -6,6 +6,18 @@ from matplotlib import cm, colors
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 
+#define the color palette for trial_come
+default_palette = sns.color_palette()
+trial_outcome_palette = {
+    'success': default_palette[0],
+    'button_press': default_palette[1],
+    'aborted' : default_palette[2],
+    'late_reach': default_palette[3],
+    'no_reach': default_palette[4],
+    'water_by_bar_off': default_palette[5],
+    'undefined': default_palette[6]
+    
+}
 
 def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=None, **kwargs):
     # kwargs: keyword argument that will be passed to the underlying sns.scatterplot function
@@ -19,14 +31,18 @@ def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=
     plt.rcParams["legend.frameon"] = False
 
     g = sns.JointGrid()
-    ax = sns.scatterplot(y=y, x=x, marker='|' ,
+    ax = sns.scatterplot(y=y, x=x, marker='|' , hue='trial_outcome', palette=trial_outcome_palette,
                        data= df2plot, ax = g.ax_joint, **kwargs)
 
-    ax.set(xlim=xlim)
+    if xlim is not None:
+        ax.set(xlim=xlim)
 
     sns.histplot(x=x, binwidth=xbinwidth, ax=g.ax_marg_x, data=df2plot)
     if ybinwidth>0 and len(df2plot[y].unique())>1:
         sns.histplot(y=y, binwidth=ybinwidth, ax=g.ax_marg_y, data=df2plot)
+        
+    sns.move_legend(ax, "upper left", bbox_to_anchor=(1.2, 1))
+
     return g
 
 

--- a/trialexp/process/pycontrol/session_analysis.py
+++ b/trialexp/process/pycontrol/session_analysis.py
@@ -186,6 +186,10 @@ def extract_trial_by_trigger(df_pycontrol, trigger, event2analysis, trial_window
     # add trial number and calculate the time from trigger
     trigger_time = df_events[(df_events.name==trigger)].time.values
     df_events, trigger_time = add_trial_nb(df_events, trigger_time,trial_window) #add trial number according to the trigger
+    
+    if len(trigger_time) == 0:
+        raise ValueError('Error: No trial can be found')
+    
     df_events = df_events.groupby('trial_nb', group_keys=False).apply(get_rel_time, trigger_name=trigger)
     df_events.dropna(subset=['trial_time'],inplace=True)
     

--- a/trialexp/process/pyphotometry/plotting_utils.py
+++ b/trialexp/process/pyphotometry/plotting_utils.py
@@ -1,9 +1,12 @@
 import matplotlib.pylab as plt
 import numpy as np 
+from trialexp.process.pycontrol.plot_utils import trial_outcome_palette
 
 def plot_and_handler_error(plot_func, **kwargs):
     # helper function to handle the error when a certain facet is nil
     if len(kwargs['data'].dropna())>0:
+        trial_outcome = kwargs['data']['trial_outcome'].iloc[0]
+        kwargs['color'] = trial_outcome_palette[trial_outcome]
         plot_func(**kwargs)
   
 def annotate_trial_number(data, **kwargs):

--- a/trialexp/process/pyphotometry/plotting_utils.py
+++ b/trialexp/process/pyphotometry/plotting_utils.py
@@ -1,4 +1,5 @@
 import matplotlib.pylab as plt
+import numpy as np 
 
 def plot_and_handler_error(plot_func, **kwargs):
     # helper function to handle the error when a certain facet is nil
@@ -12,3 +13,16 @@ def annotate_trial_number(data, **kwargs):
     
     #add vertical line for the trigger
     ax.axvline(0,ls='--', color='k', alpha=0.5)
+    
+    
+def plot_pyphoto_heatmap(dataArray):
+    # calculate the proper color scale
+    plt.figure(figsize=(4,4), dpi=300)
+    x = dataArray.data
+    x = x[~np.isnan(x)]
+    vmax = np.percentile(x,99)
+    vmin = np.percentile(x,1)
+    
+    quadMesh = dataArray.plot(vmax=vmax, vmin=-vmax, cmap='vlag')
+    
+    return quadMesh.figure

--- a/trialexp/process/pyphotometry/plotting_utils.py
+++ b/trialexp/process/pyphotometry/plotting_utils.py
@@ -20,12 +20,16 @@ def annotate_trial_number(data, **kwargs):
     
 def plot_pyphoto_heatmap(dataArray):
     # calculate the proper color scale
-    plt.figure(figsize=(4,4), dpi=300)
+    fig = plt.figure(figsize=(4,4), dpi=300)
     x = dataArray.data
     x = x[~np.isnan(x)]
-    vmax = np.percentile(x,99)
-    vmin = np.percentile(x,1)
     
-    quadMesh = dataArray.plot(vmax=vmax, vmin=-vmax, cmap='vlag')
-    
-    return quadMesh.figure
+    if len(x)>0:
+        vmax = np.percentile(x,99)
+        vmin = np.percentile(x,1)
+        
+        quadMesh = dataArray.plot(vmax=vmax, vmin=-vmax, cmap='vlag')
+        
+        return quadMesh.figure
+    else:
+        return fig

--- a/workflow/scripts/00_create_session_folders.py
+++ b/workflow/scripts/00_create_session_folders.py
@@ -35,9 +35,16 @@ tasks_params_df = pd.read_csv(tasks_params_path)
 tasks = tasks_params_df.task.values.tolist()
 
 skip_existing = True #whether to skip existing folders
+task_to_copy = ['reaching_go_spout_bar_nov22', 
+                'reaching_go_spout_incr_break2_nov22',
+                'pavlovian_spontanous_reaching_march23'] #task name to copy, if empty then search for all tasks
 # %%
 
 for task_id, task in enumerate(tasks):
+    
+    if len(task_to_copy)>0:
+        if not task in task_to_copy:
+            continue
 
     print(f'task {task_id+1}/{len(tasks)}: {task}')
     export_base_path = SESSION_ROOT_DIR/f'{task}'

--- a/workflow/scripts/02_plot_pycontrol_data.py
+++ b/workflow/scripts/02_plot_pycontrol_data.py
@@ -17,9 +17,12 @@ triggers = df_events_cond.attrs['triggers']
 #%% Plot the event plots
 df2plot = df_events_cond[df_events_cond.name=='spout'].copy()
 df2plot['trial_time'] = df2plot['trial_time']/1000
-g = plot_event_distribution(df2plot, 'trial_time', 'trial_nb', xbinwidth=0.1, ybinwidth=0, xlim=[trial_window[0]/1000, trial_window[1]/1000])
+xlim = [trial_window[0]/1000, np.percentile(df2plot['trial_time'],95)]
+g = plot_event_distribution(df2plot, 'trial_time', 'trial_nb', xbinwidth=0.1, ybinwidth=0, xlim=xlim)
 trigger_text = triggers[0].replace('_', ' ')
 style_event_distribution(g, 'Time (s)', 'Trial number', trigger_text)
 
 # %% save
 g.savefig(soutput.event_histogram, dpi=300)
+
+# %%

--- a/workflow/scripts/05_plot_pyphotometry.py
+++ b/workflow/scripts/05_plot_pyphotometry.py
@@ -4,7 +4,7 @@ Plotting of photometry data
 '''
 #%%
 from snakehelper.SnakeIOHelper import getSnake
-from trialexp.process.pyphotometry.plotting_utils import annotate_trial_number, plot_and_handler_error
+from trialexp.process.pyphotometry.plotting_utils import annotate_trial_number, plot_and_handler_error, plot_pyphoto_heatmap
 from trialexp.process.pyphotometry.utils import *
 from glob import glob
 import xarray as xr
@@ -42,7 +42,6 @@ sns.set_context('paper')
 skip_outcome = ['button_press'] #outcome variable to skip plotting (e.g. due to having too large variance)
 
 for k in xr_session.data_vars.keys():
-    
     da = xr_session[k]
     
     if 'event_time' in da.coords: # choose data varialbes that are event related
@@ -58,10 +57,10 @@ for k in xr_session.data_vars.keys():
             
         g.figure.savefig(os.path.join(figure_dir, f'{k}.png'), dpi=300, bbox_inches='tight')
         
-        # also save the heatmap
-        plt.figure(figsize=(4,4), dpi=3000)
-        xr_session[k].plot()
-        plt.gcf().savefig(os.path.join(figure_dir, f'{k}_heatmap.png'), dpi=300, bbox_inches='tight')
+        # plot heatmap
+        fig = plot_pyphoto_heatmap(xr_session[k])
+        fig.savefig(os.path.join(figure_dir, f'{k}_heatmap.png'), dpi=300, bbox_inches='tight')
 
 xr_session.close()
+
 # %%

--- a/workflow/scripts/05_plot_pyphotometry.py
+++ b/workflow/scripts/05_plot_pyphotometry.py
@@ -41,7 +41,7 @@ sns.set_context('paper')
 
 skip_outcome = ['button_press'] #outcome variable to skip plotting (e.g. due to having too large variance)
 
-for k in xr_session.data_vars.keys():
+for k in sorted(xr_session.data_vars.keys()):
     da = xr_session[k]
     
     if 'event_time' in da.coords: # choose data varialbes that are event related
@@ -50,7 +50,7 @@ for k in xr_session.data_vars.keys():
         trial_outcome = df2plot['trial_outcome'].unique()
         
         g = sns.FacetGrid(df2plot, col='trial_outcome', col_wrap=3, hue='trial_outcome')
-        g.map_dataframe(plot_and_handler_error, sns.lineplot, x='event_time', y=k)
+        g.map_dataframe(plot_and_handler_error, sns.lineplot, x='event_time', y=k, n_boot=5)
         g.map_dataframe(annotate_trial_number)
         g.set_titles(col_template='{col_name}')
         g.set_xlabels('Time (ms)')

--- a/workflow/scripts/05_plot_pyphotometry.py
+++ b/workflow/scripts/05_plot_pyphotometry.py
@@ -50,7 +50,7 @@ for k in sorted(xr_session.data_vars.keys()):
         trial_outcome = df2plot['trial_outcome'].unique()
         
         g = sns.FacetGrid(df2plot, col='trial_outcome', col_wrap=3, hue='trial_outcome')
-        g.map_dataframe(plot_and_handler_error, sns.lineplot, x='event_time', y=k, n_boot=5)
+        g.map_dataframe(plot_and_handler_error, sns.lineplot, x='event_time', y=k)
         g.map_dataframe(annotate_trial_number)
         g.set_titles(col_template='{col_name}')
         g.set_xlabels('Time (ms)')


### PR DESCRIPTION
This PR includes several improvements to the figures generated by the pipeline

1. Use colours to indicate trial outcome in event histogram. Also plot the 99 percentile of all events in a trial instead of relying on a fixed trial window to give a complete picture of animal behavior.
![event_histogram_TT002-2023-06-01-153226](https://github.com/juliencarponcy/trialexp/assets/3406709/4dcd23ba-1f98-451d-8aa8-1b6c5774e530). 

2. Adjust the color scale of the heatmap automatically to improve readability
3. Unify the color palette used for various trial_outcome across plots
4. Introduce a way to only monitor specified folders during the copying of data to the `by_session` folder to save time
