### PR TITLE
Plot style fix

### DIFF
--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -30,6 +30,11 @@ def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=
     plt.rcParams['xtick.direction'] = 'out'
     plt.rcParams['ytick.direction'] = 'out'
     plt.rcParams["legend.frameon"] = False
+    try:
+        plt.rcParams['font.family'] = ['Arial']
+    except:
+        plt.rcParams['font.family'] = ['Lato']
+
 
     g = sns.JointGrid()
     ax = sns.scatterplot(y=y, x=x, marker='|' , hue='trial_outcome', palette=trial_outcome_palette,

--- a/trialexp/process/pyphotometry/plotting_utils.py
+++ b/trialexp/process/pyphotometry/plotting_utils.py
@@ -29,7 +29,19 @@ def plot_pyphoto_heatmap(dataArray):
         vmin = np.percentile(x,1)
         
         quadMesh = dataArray.plot(vmax=vmax, vmin=-vmax, cmap='vlag')
-        
+
+        #NOTE xarray's built-in heatmap has pointy color map; replace this to a normal rectangle
+        # Cannot directly change the `extend` attribute of colorbar from DataArray.plot()
+        # So creating another one and removing the original
+
+        cbar = quadMesh.colorbar
+
+        ylabel = cbar.ax.get_ylabel()
+        cbar.remove()
+
+        new_cbar = plt.colorbar(quadMesh, ax=quadMesh.axes, extend='neither')
+        new_cbar.set_label(ylabel)
+
         return quadMesh.figure
     else:
         return fig

--- a/workflow/scripts/05_plot_pyphotometry.py
+++ b/workflow/scripts/05_plot_pyphotometry.py
@@ -12,6 +12,7 @@ from trialexp.utils.rsync import *
 import pandas as pd 
 from scipy.interpolate import interp1d
 import seaborn as sns 
+from matplotlib import pyplot as plt 
 import numpy as np
 import os
 from workflow.scripts import settings
@@ -30,12 +31,18 @@ figure_dir = soutput.trigger_photo_dir
 
 #%% plot all event-related data
 
-sns.set_style("white", {
-    "axes.spines.top": False,
-    "axes.spines.right": False,
-    "xtick.direction": "out",
-    "ytick.direction": "out",
-    })
+plt.rcParams['axes.spines.top'] = False
+plt.rcParams['axes.spines.right'] = False
+plt.rcParams['xtick.direction'] = 'out'
+plt.rcParams['ytick.direction'] = 'out'
+plt.rcParams["legend.frameon"] = False
+plt.rcParams['xtick.bottom']=True
+plt.rcParams['ytick.left']=True
+
+if os.name =='nt':
+    plt.rcParams['font.family'] = ['Arial']
+elif os.name =='posix':
+    plt.rcParams['font.family'] = ['Lato']
 
 sns.set_context('paper')
 
@@ -63,4 +70,5 @@ for k in sorted(xr_session.data_vars.keys()):
 
 xr_session.close()
 
-# %%
+# %% 
+#TODO add a vertical strip to show trial outcomes


### PR DESCRIPTION
Fixed the bug (or rather a problem in Seeborn's choice of default style) of not showing axis ticks for photometry data

Specified Lato font for Jade

Fixed the xArray's pointy colorbar (prepared by `DataArary.plot()`) to the normal rectangular style