### PR TITLE
New free water task

### DIFF
--- a/params/tasks_params.csv
+++ b/params/tasks_params.csv
@@ -30,3 +30,4 @@
 ,reaching_go_spout_bar_mar23,hold_for_water,bar; bar_off; spout; US_end_timer,break_after_abort; US_end_timer; water_on; water by bar_off; water by spout; water for free; water success; busy_win_timer; spout; button_press; waiting_for_spout,-2000;3000,,,,,,
 ,reaching_go_spout_bar_apr23,hold_for_water,bar; bar_off; spout; US_end_timer,Go_to_get_water; US_end_timer; break_after_abort; water_on; water by bar_off; water by spout; water for free; water success; button_press; busy_win_timer; spout; waiting_for_spout,-2000;3000,,,,,,
 ,pavlovian_spontanous_reaching_march23,US_timer,spout; spout_off,button_press; US_timer; US_end_timer,0;2000,,,,,,
+,reaching_go_spout_bar_free_water_june28,hold_for_water,bar; bar_off; spout; US_end_timer,Go_to_get_water; US_end_timer; break_after_abort; water_on; water by bar_off; water by spout; water for free; water success; button_press; busy_win_timer; spout; waiting_for_spout; free reward delivered,-2000;3000,,,,,,

--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -34,15 +34,32 @@ def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=
     plt.rcParams["legend.frameon"] = False
 
     g = sns.JointGrid()
+    
+    #plot spout touch
+    df_spout = df2plot[df2plot.name=='spout']
     ax = sns.scatterplot(y=y, x=x, marker='|' , hue='trial_outcome', palette=trial_outcome_palette,
-                       data= df2plot, ax = g.ax_joint, **kwargs)
+                       data= df_spout, ax = g.ax_joint, **kwargs)
+    
+    sns.histplot(x=x, binwidth=xbinwidth, ax=g.ax_marg_x, data=df_spout)
+    if ybinwidth>0 and len(df2plot[y].unique())>1:
+        sns.histplot(y=y, binwidth=ybinwidth, ax=g.ax_marg_y, data=df_spout)
+    
+    #plot aborted bar off
+    df_baroff = df2plot[(df2plot.name=='bar_off') & (df2plot.trial_outcome =='aborted')]
+    ax = sns.scatterplot(y=y, x=x, marker='.' , hue='trial_outcome', palette=trial_outcome_palette,
+                       data= df_baroff, ax = g.ax_joint, legend=False, **kwargs)
 
+    
+    # indicate the no reach condition
+    df_trial = df2plot.groupby('trial_nb').first()
+    df_noreach = df_trial[df_trial.trial_outcome.str.contains('no_reach')]
+    ax = sns.scatterplot(y=y, x=0, marker='x' , hue='trial_outcome', palette=trial_outcome_palette,
+                    data= df_noreach, ax = g.ax_joint, **kwargs)
+    
     if xlim is not None:
         ax.set(xlim=xlim)
 
-    sns.histplot(x=x, binwidth=xbinwidth, ax=g.ax_marg_x, data=df2plot)
-    if ybinwidth>0 and len(df2plot[y].unique())>1:
-        sns.histplot(y=y, binwidth=ybinwidth, ax=g.ax_marg_y, data=df2plot)
+
         
     sns.move_legend(ax, "upper left", bbox_to_anchor=(1.2, 1))
 

--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -16,7 +16,9 @@ trial_outcome_palette = {
     'no_reach': default_palette[4],
     'water_by_bar_off': default_palette[5],
     'undefined': default_palette[6],
-    'not success': default_palette[7]
+    'not success': default_palette[7],
+    'free_reward_reach': default_palette[8],
+    'free_reward_no_reach': default_palette[9],
     
 }
 

--- a/trialexp/process/pycontrol/plot_utils.py
+++ b/trialexp/process/pycontrol/plot_utils.py
@@ -62,6 +62,11 @@ def plot_event_distribution(df2plot, x, y, xbinwidth = 100, ybinwidth=100, xlim=
 
         
     sns.move_legend(ax, "upper left", bbox_to_anchor=(1.2, 1))
+    
+    # add another legend manually for the markers
+    g.figure.text(1,0.3, '|    spout touch')
+    g.figure.text(1,0.35, '*    bar off (aborted)')
+    g.figure.text(1,0.4, 'x    no reach')
 
     return g
 

--- a/trialexp/process/pycontrol/session_analysis.py
+++ b/trialexp/process/pycontrol/session_analysis.py
@@ -266,7 +266,17 @@ def compute_trial_outcome(row, task_name):
             return 'success'
         else:
             return 'undefined'
-        
+    elif task_name in ['reaching_go_spout_incr_break2_nov22']:
+        if not row.spout:
+            return 'no_reach'
+        elif row.button_press:
+            return 'button_press'   
+        elif row.spout and not row.US_end_timer:
+            return 'late_reach'
+        elif row.US_end_timer:
+            return 'success'
+        else:
+            return 'undefined'
     elif task_name in ['reaching_go_spout_bar_dual_dec22',
                        'reaching_go_spout_bar_dual_all_reward_dec22']:
         if row.break_after_abort:
@@ -283,18 +293,26 @@ def compute_trial_outcome(row, task_name):
             return 'success'
         else:
             return 'undefined'
-    elif task_name in ['reaching_go_spout_incr_break2_nov22']:
-        if not row.spout:
+    elif task_name in ['reaching_go_spout_bar_free_water_june28']:
+        if row.break_after_abort:
+            return 'aborted'
+        elif row['free reward delivered']:
+            if row.spout:
+                return 'free_reward_reach'
+            else:
+                return 'free_reward_no_reach'
+        elif not row.spout:
             return 'no_reach'
         elif row.button_press:
-            return 'button_press'   
-        elif row.spout and not row.US_end_timer:
+            return 'button_press'
+        elif row['water by bar_off']:
+            return 'water_by_bar_off'
+        elif row.spout and not row.water_on:
             return 'late_reach'
-        elif row.US_end_timer:
+        elif row['water by spout']:
             return 'success'
         else:
             return 'undefined'
-
     else:
         if row.success:
             return 'success'

--- a/workflow/scripts/02_plot_pycontrol_data.py
+++ b/workflow/scripts/02_plot_pycontrol_data.py
@@ -15,7 +15,6 @@ trial_window = df_events_cond.attrs['trial_window']
 triggers = df_events_cond.attrs['triggers']
 
 #%% Plot the event plots
-# df2plot = df_events_cond[df_events_cond.name=='spout'].copy()
 df2plot = df_events_cond.copy()
 df2plot['trial_time'] = df2plot['trial_time']/1000
 xlim = [trial_window[0]/1000, np.percentile(df2plot['trial_time'],95)]

--- a/workflow/scripts/02_plot_pycontrol_data.py
+++ b/workflow/scripts/02_plot_pycontrol_data.py
@@ -15,7 +15,8 @@ trial_window = df_events_cond.attrs['trial_window']
 triggers = df_events_cond.attrs['triggers']
 
 #%% Plot the event plots
-df2plot = df_events_cond[df_events_cond.name=='spout'].copy()
+# df2plot = df_events_cond[df_events_cond.name=='spout'].copy()
+df2plot = df_events_cond.copy()
 df2plot['trial_time'] = df2plot['trial_time']/1000
 xlim = [trial_window[0]/1000, np.percentile(df2plot['trial_time'],95)]
 g = plot_event_distribution(df2plot, 'trial_time', 'trial_nb', xbinwidth=0.1, ybinwidth=0, xlim=xlim)


### PR DESCRIPTION
This PR adds support for the new task `reaching_go_spout_bar_free_water_june28`

It also adds more information to the event plot to show bar off event in the aborted trial and when the animals do not reach out.

![event_histogram_TT001-2023-06-28-155944](https://github.com/juliencarponcy/trialexp/assets/3406709/48022675-0a39-412b-afbc-b0f02b9e424d)

